### PR TITLE
Bump peter-evans/create-pull-request to v7 for sign-commits support

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -43,7 +43,7 @@ jobs:
       # PR — both required by the org ruleset on `main`.
       - name: Open signed PR with updates
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sign-commits: true


### PR DESCRIPTION
Follow-up to #11. `peter-evans/create-pull-request@v6` does **not** support the `sign-commits` input — the action silently ignores it and falls back to plain `git commit`, so the commits produced by the daily updater are unsigned and rejected by the signed-commits rule. The `sign-commits` flag was added in v7.

Diff is one line:
```diff
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)