### PR TITLE
Track armoriq/armorCodex

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ github:
     - armoriq/armoriq-sdk-customer
     - armoriq/conmap
     - armoriq/armorClaude
+    - armoriq/armorCodex
 
 discord:
   - 1450796662334423135


### PR DESCRIPTION
Adds `armoriq/armorCodex` to the github.repos list so daily fetches start collecting its clones (plus stars/forks/open issues).

The first workflow run after this merges will backfill up to 14 days of clone history from GitHub's `/traffic/clones` rolling window automatically.